### PR TITLE
Add WebRTC SFU Sora

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
     <ul class="shuffle">
       <li> Red5 Pro Server <a href="https://red5pro.com"> https://red5pro.com </a> </li>
       <li> AWS (Amazon Chime SDK) <a href="https://aws.amazon.com/chime/chime-sdk/"> https://aws.amazon.com/chime/chime-sdk/ </a> </li>
+      <li> WebRTC SFU Sora (Japanese Only) <a href="https://sora.shiguredo.jp/"> https://sora.shiguredo.jp/ </a> </li>
     </ul>
 
     <h1> Libraries </h1>


### PR DESCRIPTION
This PR adds WebRTC SFU Sora to the list of "Servers (non-free)".